### PR TITLE
Cloud Run Jobsのスケジュール実行が認証問題でエラーになっていたのを修正

### DIFF
--- a/infra/scheduler.tf
+++ b/infra/scheduler.tf
@@ -5,9 +5,9 @@ resource "google_cloud_scheduler_job" "dbt_job_scheduler" {
 
   http_target {
     http_method = "POST"
-    uri         = "https://asia-northeast1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/my-blog-analysis-dbt-job:run"
+    uri         = "https://asia-northeast1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.dbt_job.name}:run"
 
-    oidc_token {
+    oauth_token {
       service_account_email = google_service_account.dbt_runner.email
     }
   }


### PR DESCRIPTION
## エラー内容
URL_ERROR-ERROR_AUTHENTICATION. Original HTTP response code number = 401

## 参考記事
- https://docs.cloud.google.com/scheduler/docs/http-target-auth?hl=ja#gcloud
- https://qiita.com/shun198/items/d7d206b618aeee4436e6
- https://docs.cloud.google.com/batch/docs/create-run-job-using-terraform-and-cloud-scheduler?hl=ja#create-terraform-directory-and-file