### PR TITLE
GCSとbackendのmodules化

### DIFF
--- a/env/dev/gcs.tf
+++ b/env/dev/gcs.tf
@@ -1,35 +1,5 @@
-resource "google_storage_bucket" "backend_bucket" {
-  name     = "${var.project_id}-tfstate-bucket"
-  location = "us-west1"
+module "backend_bucket" {
+  source = "../../modules/gcs"
 
-  force_destroy               = false
-  public_access_prevention    = "enforced"
-  uniform_bucket_level_access = true
-
-  versioning {
-    enabled = true
-  }
-
-  lifecycle_rule {
-    action {
-      type = "Delete"
-    }
-    condition {
-      num_newer_versions = 5
-    }
-  }
-}
-
-resource "local_file" "default" {
-  file_permission = "0644"
-  filename        = "./backend.tf"
-
-  content = <<-EOT
-  terraform {
-    backend "gcs" {
-      bucket = "${google_storage_bucket.backend_bucket.name}"
-      prefix = "terraform/state"
-    }
-  }
-  EOT
+  project_id = var.project_id
 }

--- a/env/prod/gcs.tf
+++ b/env/prod/gcs.tf
@@ -1,35 +1,5 @@
-resource "google_storage_bucket" "backend_bucket" {
-  name     = "${var.project_id}-tfstate-bucket"
-  location = "us-west1"
+module "backend_bucket" {
+  source = "../../modules/gcs"
 
-  force_destroy               = false
-  public_access_prevention    = "enforced"
-  uniform_bucket_level_access = true
-
-  versioning {
-    enabled = true
-  }
-
-  lifecycle_rule {
-    action {
-      type = "Delete"
-    }
-    condition {
-      num_newer_versions = 5
-    }
-  }
-}
-
-resource "local_file" "default" {
-  file_permission = "0644"
-  filename        = "./backend.tf"
-
-  content = <<-EOT
-  terraform {
-    backend "gcs" {
-      bucket = "${google_storage_bucket.backend_bucket.name}"
-      prefix = "terraform/state"
-    }
-  }
-  EOT
+  project_id = var.project_id
 }

--- a/modules/gcs/main.tf
+++ b/modules/gcs/main.tf
@@ -1,0 +1,35 @@
+resource "google_storage_bucket" "backend_bucket" {
+  name     = "${var.project_id}-tfstate-bucket"
+  location = "us-west1"
+
+  force_destroy               = false
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      num_newer_versions = 5
+    }
+  }
+}
+
+resource "local_file" "default" {
+  file_permission = "0644"
+  filename        = "./backend.tf"
+
+  content = <<-EOT
+  terraform {
+    backend "gcs" {
+      bucket = "${google_storage_bucket.backend_bucket.name}"
+      prefix = "terraform/state"
+    }
+  }
+  EOT
+}

--- a/modules/gcs/variables.tf
+++ b/modules/gcs/variables.tf
@@ -1,0 +1,1 @@
+variable "project_id" {}


### PR DESCRIPTION
module化するだけならplanでno changeとなる想定だったがならなかった
↓
Claude Codeに確認したところ下記とのこと
```
Terraformはリソースの**アドレス（パス）**で状態を管理しています。モジュール化すると、リソースのアドレスが変わるため「別のリソース」と認識されてしまいます。
```

movedというのを使うと良さそうということで下記を参考に

- https://dev.classmethod.jp/articles/terraform-moved-block-resource-refactoring/
- https://zenn.dev/delta_tsuruta/articles/d231ab2fbd39a5
- https://qiita.com/m-oka-system/items/e69d6bb86eae74619a27

envフォルダのファイルに下記を記述でno changeにする
```
moved {
  from = google_storage_bucket.backend_bucket
  to = module.backend_bucket.google_storage_bucket.backend_bucket
}

moved {
  from = local_file.default
  to = module.backend_bucket.local_file.default
}
```

terraform applyを実行し、その後movedの記述をなくしてPRを作成
