### PR TITLE
Workload Identityのリソースを追加

### DIFF
--- a/env/dev/wi.tf
+++ b/env/dev/wi.tf
@@ -1,0 +1,28 @@
+resource "google_iam_workload_identity_pool" "github_pool" {
+  description               = "GitHub Actions から実行する際に使用"
+  disabled                  = false
+  display_name              = "github-pool"
+  project                   = var.project_id
+  workload_identity_pool_id = "github-pool"
+}
+
+resource "google_iam_workload_identity_pool_provider" "github_pool_provider" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-pool-provider"
+
+  # 外部のリポジトリから使えないようにするため、attribute_conditionを必ず設定する
+  attribute_condition = "assertion.repository == 'Satoshi-Moriya/my_blog_analytics_etl'"
+  attribute_mapping = {
+    "attribute.repository"       = "assertion.repository"
+    "attribute.repository_owner" = "assertion.repository_owner"
+    "google.subject"             = "assertion.sub"
+  }
+  description  = null
+  disabled     = false
+  display_name = "github-pool-provider"
+  project      = var.project_id
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}


### PR DESCRIPTION
https://github.com/Satoshi-Moriya/my_blog_analysis_infra/pull/21
上記の内容をmainに直接反映させるようにした

一度リソースを作って、削除していたが、Workload Identity Pool は削除しても 30日間は "soft-deleted" 状態で残り、同じ ID で再作成できません（論理削除されたプールが残っていたっぽい）

そのため下記の手順で解決した

1. workload_identity_poolをコンソール画面から復元
2. workload_identity_pool_providerを下記コマンドで復元
```
gcloud iam workload-identity-pools providers undelete github-pool-provider \
  --workload-identity-pool=github-pool \
  --location=global \
  --project=project_name
```
3. 下記import文を使ってwi.tfに記載
```
import {
  to = google_iam_workload_identity_pool.github_pool
  id = "projects/${var.project_id}/locations/global/workloadIdentityPools/github-pool"
}

import {
  to = google_iam_workload_identity_pool_provider.github_pool_provider
  id = "projects/${var.project_id}/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider"
}
```

4. terraform planで下記のようなメッセージになればOKっぽい
```
Plan: 2 to import, 0 to add, 0 to change, 0 to destroy.
```
5. terraform applyで適応
6. import文は削除した