### PR TITLE
prod環境の新しいデータセットを追加

### DIFF
--- a/env/prod/datasets.tf
+++ b/env/prod/datasets.tf
@@ -30,3 +30,36 @@ resource "google_bigquery_dataset" "prod_mart" {
     environment = "prod"
   }
 }
+
+resource "google_bigquery_dataset" "staging" {
+  dataset_id  = "staging"
+  project     = var.project_id
+  location    = var.location
+  description = "prod環境のstaging層用のdataset"
+
+  labels = {
+    environment = "prod"
+  }
+}
+
+resource "google_bigquery_dataset" "intermediate" {
+  dataset_id  = "intermediate"
+  project     = var.project_id
+  location    = var.location
+  description = "prod環境のintermediate層用のdataset"
+
+  labels = {
+    environment = "prod"
+  }
+}
+
+resource "google_bigquery_dataset" "mart" {
+  dataset_id  = "mart"
+  project     = var.project_id
+  location    = var.location
+  description = "prod環境のmart層用のdataset"
+
+  labels = {
+    environment = "prod"
+  }
+}


### PR DESCRIPTION
先に既存のデータセットのテーブルを新しいデータセットにコピーして作成しておくために一旦データセットを追加